### PR TITLE
Add basic sidebar menu

### DIFF
--- a/gestor_personal_tablero_v_1.html
+++ b/gestor_personal_tablero_v_1.html
@@ -7,57 +7,62 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="container">
-    <div class="header">
-      <div class="toolbar">
-        <button class="btn primary" id="btnNueva">➕ Nueva tarea</button>
-        <button class="btn" id="btnExport">Exportar JSON</button>
-        <input class="input" id="q" placeholder="Buscar… (título/desc/etiquetas)" style="width:260px"/>
-        <select class="select" id="fProyecto"></select>
-        <select class="select" id="fObjetivo"></select>
-        <select class="select" id="fTipo"></select>
-        <input class="input" id="fFecha" type="date"/>
-        <button class="btn neutral" id="btnHoy">Hoy</button>
-        <div class="spacer"></div>
-        <div class="kpis">
-          <span class="dot st-programado"></span><span class="small">Prog:</span><b id="kProg">0</b>
-          <span class="dot st-trabajando" style="margin-left:10px"></span><span class="small">Trab:</span><b id="kTrab">0</b>
-          <span class="dot st-rezagado" style="margin-left:10px"></span><span class="small">Rezag:</span><b id="kRez">0</b>
-          <span class="dot st-cerrado" style="margin-left:10px"></span><span class="small">Cerr:</span><b id="kCer">0</b>
+  <div class="layout">
+    <nav class="sidebar">
+      <a href="#" class="active">Tablero</a>
+    </nav>
+    <div class="main">
+      <div class="container">
+        <div class="header">
+          <div class="toolbar">
+            <button class="btn primary" id="btnNueva">➕ Nueva tarea</button>
+            <button class="btn" id="btnExport">Exportar JSON</button>
+            <input class="input" id="q" placeholder="Buscar… (título/desc/etiquetas)" style="width:260px"/>
+            <select class="select" id="fProyecto"></select>
+            <select class="select" id="fObjetivo"></select>
+            <select class="select" id="fTipo"></select>
+            <input class="input" id="fFecha" type="date"/>
+            <button class="btn neutral" id="btnHoy">Hoy</button>
+            <div class="spacer"></div>
+            <div class="kpis">
+              <span class="dot st-programado"></span><span class="small">Prog:</span><b id="kProg">0</b>
+              <span class="dot st-trabajando" style="margin-left:10px"></span><span class="small">Trab:</span><b id="kTrab">0</b>
+              <span class="dot st-rezagado" style="margin-left:10px"></span><span class="small">Rezag:</span><b id="kRez">0</b>
+              <span class="dot st-cerrado" style="margin-left:10px"></span><span class="small">Cerr:</span><b id="kCer">0</b>
+            </div>
+          </div>
         </div>
+
+        <div class="card">
+          <table>
+            <thead>
+              <tr>
+                <th style="width:44px"></th>
+                <th style="width:36px">#</th>
+                <th>TÍTULO</th>
+                <th style="width:120px">ESTADO</th>
+                <th style="width:130px">H. COMPROMISO</th>
+                <th style="width:110px">T. TOTAL</th>
+                <th style="width:110px">T. HOY</th>
+                <th style="width:120px">ACCIONES</th>
+              </tr>
+            </thead>
+            <tbody id="tbody"></tbody>
+          </table>
+        </div>
+
+        <div class="footer small">Local • v1 (HTML/CSS/JS). Sin backend. Persistencia en localStorage. Adjuntos guardados como DataURL (límite recomendado ≤ 1 MB por archivo).</div>
       </div>
-    </div>
 
-    <div class="card">
-      <table>
-        <thead>
-          <tr>
-            <th style="width:44px"></th>
-            <th style="width:36px">#</th>
-            <th>TÍTULO</th>
-            <th style="width:120px">ESTADO</th>
-            <th style="width:130px">H. COMPROMISO</th>
-            <th style="width:110px">T. TOTAL</th>
-            <th style="width:110px">T. HOY</th>
-            <th style="width:120px">ACCIONES</th>
-          </tr>
-        </thead>
-        <tbody id="tbody"></tbody>
-      </table>
-    </div>
-
-    <div class="footer small">Local • v1 (HTML/CSS/JS). Sin backend. Persistencia en localStorage. Adjuntos guardados como DataURL (límite recomendado ≤ 1 MB por archivo).</div>
-  </div>
-
-  <!-- MODAL NUEVA / EDITAR -->
-  <div class="modal-backdrop" id="modalEditBg">
-    <div class="modal" role="dialog" aria-modal="true">
-      <header>
-        <strong id="modalTitle">Nueva tarea</strong>
-        <button class="btn" onclick="closeEdit()">✕</button>
-      </header>
-      <div class="body">
-        <div class="grid">
+      <!-- MODAL NUEVA / EDITAR -->
+      <div class="modal-backdrop" id="modalEditBg">
+        <div class="modal" role="dialog" aria-modal="true">
+          <header>
+            <strong id="modalTitle">Nueva tarea</strong>
+            <button class="btn" onclick="closeEdit()">✕</button>
+          </header>
+          <div class="body">
+            <div class="grid">
           <div>
             <label>Título</label>
             <input id="mTitulo" type="text"/>
@@ -163,6 +168,8 @@
     <button onclick="actions.playPause()">▶️ Iniciar / Pausar</button>
     <button onclick="actions.programarHoy()">Programar hoy</button>
     <button onclick="actions.cerrar()">✅ Cerrar (requiere adjunto)</button>
+  </div>
+  </div>
   </div>
 
   <script src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -16,6 +16,11 @@
     body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.35 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial}
     button, input, select, textarea{font:inherit}
     /* Layout */
+    .layout{display:flex;min-height:100vh}
+    .sidebar{width:200px;background:var(--panel);border-right:1px solid var(--line);padding:20px}
+    .sidebar a{display:block;padding:8px;border-radius:8px;color:var(--ink);text-decoration:none;margin-bottom:4px}
+    .sidebar a.active{background:var(--primary);color:#fff}
+    .main{flex:1;overflow:auto}
     .container{max-width:1200px;margin:18px auto;padding:0 16px}
     .card{background:var(--panel);border:1px solid var(--line);border-radius:10px;box-shadow:0 1px 0 rgba(0,0,0,.04)}
     .header{position:sticky;top:0;z-index:10;background:var(--bg);box-shadow:0 2px 0 rgba(0,0,0,.02);padding:8px 0 12px}


### PR DESCRIPTION
## Summary
- introduce a flex-based layout with a sidebar placeholder
- place existing workboard inside a main content area
- style sidebar navigation and active state

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc2a7f8d0832090ce01669e9711cd