### PR TITLE
Update running task color and overdue logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -31,15 +31,14 @@
   // ====== Estado derivado ==================================================
   function deriveState(t){
     if(t.estado === 'CERRADO') return 'CERRADO';
-    const now = Date.now();
     const running = !!t.timerStart;
     if(running) return 'TRABAJANDO';
     const spent = getTotalMs(t);
     if(spent>0) return 'EMPEZADO';
     if(t.fechaCompromiso){
-      const comp = new Date(t.fechaCompromiso);
-      const isPast = dayEnd(new Date()) > comp && (!t.programadoPara || new Date(t.programadoPara) <= dayEnd(new Date()));
-      if(isPast) return 'REZAGADO';
+      const today = dayStart(new Date());
+      const comp = dayStart(new Date(t.fechaCompromiso + 'T00:00:00'));
+      if(today > comp) return 'REZAGADO';
     }
     return 'PROGRAMADO';
   }

--- a/style.css
+++ b/style.css
@@ -41,13 +41,13 @@
     tbody tr:hover td{background:#f9fafb}
 
     /* Estado tintes */
-    .row--trabajando td{background:#fff7ed} /* naranja claro */
+    .row--trabajando td{background:#e0f2fe} /* celeste claro */
     .row--rezagado td{background:#fef2f2}
     .row--programado td{background:#eff6ff}
     .row--cerrado td{background:#f0fdf4}
 
     .badge{display:inline-flex;align-items:center;gap:6px;padding:2px 8px;border-radius:8px;font-size:12px;font-weight:600}
-    .badge.trabajando{background:#ffedd5;color:#9a3412}
+    .badge.trabajando{background:#e0f2fe;color:#075985}
     .badge.rezagado{background:#fee2e2;color:#991b1b}
     .badge.programado{background:#dbeafe;color:#1e40af}
     .badge.empezado{background:#e5e7eb;color:#111827}
@@ -60,7 +60,7 @@
     .menu button:hover{background:#f3f4f6}
 
     .status-dot{width:10px;height:10px;border-radius:50%;display:inline-block}
-    .st-trabajando{background:var(--warn)}
+    .st-trabajando{background:var(--tag)}
     .st-programado{background:var(--primary)}
     .st-rezagado{background:var(--bad)}
     .st-empezado{background:#6b7280}


### PR DESCRIPTION
## Summary
- change running task highlight from yellow to light blue
- determine overdue state by comparing `fecha compromiso` with current date

## Testing
- `node --check script.js`
- `node - <<'NODE'
function dayStart(d){ return new Date(d.getFullYear(), d.getMonth(), d.getDate()); }
function getTotalMs(t){ return 0; }
function deriveState(t){
  if(t.estado === 'CERRADO') return 'CERRADO';
  const running = !!t.timerStart;
  if(running) return 'TRABAJANDO';
  const spent = getTotalMs(t);
  if(spent>0) return 'EMPEZADO';
  if(t.fechaCompromiso){
    const today = dayStart(new Date());
    const comp = dayStart(new Date(t.fechaCompromiso + 'T00:00:00'));
    if(today > comp) return 'REZAGADO';
  }
  return 'PROGRAMADO';
}
const today = new Date().toISOString().slice(0,10);
const tomorrow = new Date(Date.now()+86400000).toISOString().slice(0,10);
const yesterday = new Date(Date.now()-86400000).toISOString().slice(0,10);
console.log('today', today);
console.log('tomorrow', tomorrow, '=>', deriveState({fechaCompromiso:tomorrow}));
console.log('yesterday', yesterday, '=>', deriveState({fechaCompromiso:yesterday}));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68bdc3d244ac8320ab74f85d7a32e24e