### PR TITLE
Add sidebar navigation scaffold

### DIFF
--- a/gestor_personal_tablero_v_1.html
+++ b/gestor_personal_tablero_v_1.html
@@ -6,8 +6,16 @@
   <title>Tablero Personal</title>
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <div class="container">
+  <body>
+    <aside class="sidebar">
+      <button class="burger" id="menuToggle">☰</button>
+      <h2>Menu</h2>
+      <nav>
+        <a href="#" class="active">Workboard</a>
+      </nav>
+    </aside>
+    <div class="content">
+    <div class="container">
     <div class="header">
       <div class="toolbar">
         <button class="btn primary" id="btnNueva">➕ Nueva tarea</button>
@@ -158,13 +166,14 @@
   </div>
 
   <!-- MENU flotante plantilla -->
-  <div class="menu" id="rowMenu">
-    <button onclick="actions.detalles()">Ver / Editar…</button>
-    <button onclick="actions.playPause()">▶️ Iniciar / Pausar</button>
-    <button onclick="actions.programarHoy()">Programar hoy</button>
-    <button onclick="actions.cerrar()">✅ Cerrar (requiere adjunto)</button>
-  </div>
+    <div class="menu" id="rowMenu">
+      <button onclick="actions.detalles()">Ver / Editar…</button>
+      <button onclick="actions.playPause()">▶️ Iniciar / Pausar</button>
+      <button onclick="actions.programarHoy()">Programar hoy</button>
+      <button onclick="actions.cerrar()">✅ Cerrar (requiere adjunto)</button>
+    </div>
+    </div>
 
-  <script src="script.js"></script>
-</body>
-</html>
+    <script src="script.js"></script>
+  </body>
+  </html>

--- a/script.js
+++ b/script.js
@@ -491,3 +491,6 @@
   });
 
   // ====== Tip: click fuera cierra menú ====================================
+  document.getElementById('menuToggle')?.addEventListener('click', ()=>{
+    document.body.classList.toggle('collapsed');
+  });

--- a/style.css
+++ b/style.css
@@ -13,7 +13,16 @@
       --badge:#111827;   /* header de tabla negro gris */
     }
     html,body{height:100%}
-    body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.35 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial}
+    body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.35 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial;}
+      .sidebar{width:200px;position:fixed;top:0;bottom:0;left:0;background:#333;color:#fff;padding:20px;box-sizing:border-box;transition:width .3s}
+      .sidebar h2{margin-top:0;font-size:18px;color:#fff}
+      .sidebar a{display:block;color:#fff;text-decoration:none;margin:8px 0;padding:8px;border-radius:4px}
+      .sidebar a:hover,.sidebar a.active{background:#fff;color:#333}
+      .content{margin-left:200px;overflow:auto;transition:margin-left .3s}
+      body.collapsed .sidebar{width:60px;padding:10px}
+      body.collapsed .sidebar h2,body.collapsed .sidebar nav{display:none}
+      body.collapsed .content{margin-left:60px}
+      .burger{background:#333;border:0;color:#fff;padding:12px;border-radius:8px;cursor:pointer;font-size:24px;font-weight:bold}
     button, input, select, textarea{font:inherit}
     /* Layout */
     .container{max-width:1200px;margin:18px auto;padding:0 16px}


### PR DESCRIPTION
## Summary
- add basic sidebar layout with Workboard link
- style sidebar and flex layout for future navigation
- make sidebar collapsible with hamburger toggle and hover styles
- move hamburger toggle into sidebar and keep collapsed version visible

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdc2a7f8d0832090ce01669e9711cd