### PR TITLE
feat: add backlog backlog page for unscheduled tasks

### DIFF
--- a/backlog.html
+++ b/backlog.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Backlog</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <aside class="sidebar">
+    <button class="burger" id="menuToggle">☰</button>
+    <h2>Menu</h2>
+    <nav>
+      <a href="gestor_personal_tablero_v_1.html">Workboard</a>
+      <a href="backlog.html" class="active">Backlog</a>
+    </nav>
+  </aside>
+  <div class="content">
+    <div class="container">
+      <div class="header">
+        <div class="toolbar">
+          <button class="btn primary" id="btnNueva">➕ Nueva tarea</button>
+        </div>
+      </div>
+      <div class="card">
+        <table>
+          <thead>
+            <tr>
+              <th>Título</th>
+              <th>Proyecto</th>
+              <th>Objetivo</th>
+              <th>Tipo</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody id="tbody"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal Nueva tarea -->
+  <div class="modal-backdrop" id="modalEditBg">
+    <div class="modal" role="dialog" aria-modal="true">
+      <header>
+        <strong id="modalTitle">Nueva tarea</strong>
+        <button class="btn" onclick="closeEdit()">✕</button>
+      </header>
+      <div class="body">
+        <div class="grid">
+          <div>
+            <label>Título</label>
+            <input id="mTitulo" type="text"/>
+          </div>
+          <div>
+            <label>Tipo</label>
+            <div class="row">
+              <select id="mTipo"></select>
+              <button class="btn" onclick="addCatalog('tipo')">＋</button>
+            </div>
+          </div>
+          <div>
+            <label>Proyecto</label>
+            <div class="row">
+              <select id="mProyecto"></select>
+              <button class="btn" onclick="addCatalog('proyecto')">＋</button>
+            </div>
+          </div>
+          <div>
+            <label>Objetivo</label>
+            <div class="row">
+              <select id="mObjetivo"></select>
+              <button class="btn" onclick="addCatalog('objetivo')">＋</button>
+            </div>
+          </div>
+          <div style="grid-column:1/3">
+            <label>Descripción</label>
+            <textarea id="mDescripcion" placeholder="Detalles, pasos, etc."></textarea>
+          </div>
+          <div style="grid-column:1/3">
+            <label>Etiquetas (coma)</label>
+            <input id="mTags" type="text" placeholder="ej. QA, script, docs"/>
+          </div>
+        </div>
+      </div>
+      <footer>
+        <button class="btn" onclick="closeEdit()">Cancelar</button>
+        <button class="btn primary" onclick="saveFromModal()">Guardar</button>
+      </footer>
+    </div>
+  </div>
+
+  <!-- Modal Programar -->
+  <div class="modal-backdrop" id="modalProgBg">
+    <div class="modal" role="dialog" aria-modal="true">
+      <header>
+        <strong>Programar tarea</strong>
+        <button class="btn" onclick="closeProgramar()">✕</button>
+      </header>
+      <div class="body">
+        <div class="grid">
+          <div>
+            <label>Programado para</label>
+            <input id="pProgramado" type="date"/>
+          </div>
+          <div>
+            <label>Fecha compromiso</label>
+            <input id="pCompromiso" type="date"/>
+          </div>
+        </div>
+      </div>
+      <footer>
+        <button class="btn" onclick="closeProgramar()">Cancelar</button>
+        <button class="btn primary" onclick="saveProgramar()">Guardar</button>
+      </footer>
+    </div>
+  </div>
+
+  <script src="backlog.js"></script>
+</body>
+</html>

--- a/backlog.js
+++ b/backlog.js
@@ -1,0 +1,132 @@
+// ====== Datos y almacenamiento (LocalStorage) ============================
+const LS_KEY = 'wb_tasks_v1';
+const LS_CAT = 'wb_catalogs_v1';
+
+/** @type {Array<any>} */
+let tasks = [];
+let catalogs = { tipos:["General"], proyectos:["Personal"], objetivos:["General"] };
+
+function load(){
+  try{ tasks = JSON.parse(localStorage.getItem(LS_KEY)||'[]'); }catch{ tasks=[]; }
+  try{ catalogs = JSON.parse(localStorage.getItem(LS_CAT)||'null') || catalogs; }catch{}
+}
+function save(){
+  localStorage.setItem(LS_KEY, JSON.stringify(tasks));
+  localStorage.setItem(LS_CAT, JSON.stringify(catalogs));
+}
+
+// ====== Utilidades =======================================================
+function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#039;"}[c])); }
+function getTask(id){ return tasks.find(t=>t.id===id); }
+function fillSelect(sel, items){ sel.innerHTML=''; items.forEach(x=>{ const o=document.createElement('option'); o.value=o.textContent=x; sel.appendChild(o); }); }
+function fillSelects(){ fillSelect(mTipo, catalogs.tipos); fillSelect(mProyecto, catalogs.proyectos); fillSelect(mObjetivo, catalogs.objetivos); }
+
+function addCatalog(kind){
+  const name = prompt('Nuevo '+kind+':');
+  if(!name) return;
+  const list = kind==='tipo'? catalogs.tipos : (kind==='proyecto'? catalogs.proyectos : catalogs.objetivos);
+  if(!list.includes(name)) list.push(name);
+  save(); fillSelects();
+}
+
+// ====== UI ================================================================
+const tbody = document.getElementById('tbody');
+const btnNueva = document.getElementById('btnNueva');
+btnNueva.addEventListener('click', ()=> openEdit());
+
+tbody.addEventListener('click', ev=>{
+  const btn = ev.target.closest('button');
+  if(!btn) return;
+  const id = btn.getAttribute('data-id');
+  if(btn.classList.contains('programar')) openProgramar(id);
+});
+
+function render(){
+  const list = tasks.filter(t=> !t.programadoPara && !t.fechaCompromiso);
+  tbody.innerHTML='';
+  list.forEach(t=>{
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${escapeHtml(t.titulo)}</td>
+      <td>${escapeHtml(t.proyecto||'—')}</td>
+      <td>${escapeHtml(t.objetivo||'—')}</td>
+      <td><span class="chip">${escapeHtml(t.tipo||'General')}</span></td>
+      <td><button class="btn programar" data-id="${t.id}">Programar</button></td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+// ====== Modal crear =======================================================
+let editingId = null;
+const modalEditBg = document.getElementById('modalEditBg');
+const mTitulo = document.getElementById('mTitulo');
+const mDescripcion = document.getElementById('mDescripcion');
+const mTipo = document.getElementById('mTipo');
+const mProyecto = document.getElementById('mProyecto');
+const mObjetivo = document.getElementById('mObjetivo');
+const mTags = document.getElementById('mTags');
+
+function openEdit(){
+  editingId = null;
+  mTitulo.value='';
+  mDescripcion.value='';
+  mTags.value='';
+  fillSelects();
+  modalEditBg.style.display='flex';
+}
+function closeEdit(){ modalEditBg.style.display='none'; editingId=null; }
+
+function saveFromModal(){
+  const data = {
+    titulo: mTitulo.value.trim(),
+    descripcion: mDescripcion.value.trim(),
+    tipo: mTipo.value,
+    proyecto: mProyecto.value,
+    objetivo: mObjetivo.value,
+    tags: mTags.value.split(',').map(s=>s.trim()).filter(Boolean)
+  };
+  if(!data.titulo) return alert('Título requerido.');
+  const t = {
+    id: crypto.randomUUID(),
+    creadoEn: new Date().toISOString(),
+    estado: 'PROGRAMADO',
+    sesiones: [],
+    timerStart: null,
+    programadoPara: null,
+    fechaCompromiso: null,
+    recurrencia: 'ninguna',
+    adjuntos: [],
+    ...data
+  };
+  tasks.unshift(t); save(); closeEdit(); render();
+}
+
+// ====== Modal programar ===================================================
+let progId = null;
+const modalProgBg = document.getElementById('modalProgBg');
+const pProgramado = document.getElementById('pProgramado');
+const pCompromiso = document.getElementById('pCompromiso');
+
+function openProgramar(id){
+  const t = getTask(id); if(!t) return;
+  progId = id;
+  pProgramado.value = t.programadoPara||'';
+  pCompromiso.value = t.fechaCompromiso||'';
+  modalProgBg.style.display='flex';
+}
+function closeProgramar(){ modalProgBg.style.display='none'; progId=null; }
+function saveProgramar(){
+  const t = getTask(progId); if(!t) return;
+  t.programadoPara = pProgramado.value || null;
+  t.fechaCompromiso = pCompromiso.value || null;
+  save(); closeProgramar(); render();
+}
+
+// ====== Boot ==============================================================
+load();
+fillSelects();
+render();
+
+document.getElementById('menuToggle')?.addEventListener('click', ()=>{
+  document.body.classList.toggle('collapsed');
+});

--- a/gestor_personal_tablero_v_1.html
+++ b/gestor_personal_tablero_v_1.html
@@ -11,7 +11,8 @@
       <button class="burger" id="menuToggle">☰</button>
       <h2>Menu</h2>
       <nav>
-        <a href="#" class="active">Workboard</a>
+        <a href="gestor_personal_tablero_v_1.html" class="active">Workboard</a>
+        <a href="backlog.html">Backlog</a>
       </nav>
     </aside>
     <div class="content">

--- a/script.js
+++ b/script.js
@@ -111,6 +111,7 @@ function load(){
     const fp = fProyecto.value, fo = fObjetivo.value, ft = fTipo.value;
 
     const filtered = tasks.filter(t=>{
+      if(!t.programadoPara && !t.fechaCompromiso) return false; // omit tasks sin fecha (backlog)
       if(fp && t.proyecto!==fp) return false;
       if(fo && t.objetivo!==fo) return false;
       if(ft && t.tipo!==ft) return false;


### PR DESCRIPTION
## Summary
- add backlog page to capture tasks without dates
- allow scheduling backlog tasks to move to the main board
- hide unscheduled tasks from main workboard

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcbf0807483208d669f16e6c3ccfa