### PR TITLE
Add backlog page for unscheduled tasks

### DIFF
--- a/backlog.html
+++ b/backlog.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Backlog</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <aside class="sidebar">
+    <button class="burger" id="menuToggle">☰</button>
+    <h2>Menu</h2>
+    <nav>
+      <a href="gestor_personal_tablero_v_1.html">Workboard</a>
+      <a href="#" class="active">Backlog</a>
+    </nav>
+  </aside>
+  <div class="content">
+    <div class="container">
+      <div class="header">
+        <div class="toolbar">
+          <button class="btn primary" id="btnNueva">➕ Nueva tarea</button>
+        </div>
+      </div>
+      <div class="card">
+        <table>
+          <thead>
+            <tr>
+              <th style="width:36px">#</th>
+              <th>TÍTULO</th>
+              <th style="width:120px">ACCIONES</th>
+            </tr>
+          </thead>
+          <tbody id="tbody"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- MODAL NUEVA / EDITAR -->
+  <div class="modal-backdrop" id="modalEditBg">
+    <div class="modal" role="dialog" aria-modal="true">
+      <header>
+        <strong id="modalTitle">Nueva tarea</strong>
+        <button class="btn" onclick="closeEdit()">✕</button>
+      </header>
+      <div class="body">
+        <div class="grid">
+          <div>
+            <label>Título</label>
+            <input id="mTitulo" type="text"/>
+          </div>
+          <div>
+            <label>Tipo</label>
+            <div class="row">
+              <select id="mTipo"></select>
+              <button class="btn" onclick="ui.addCatalog('tipo')">＋</button>
+            </div>
+          </div>
+          <div>
+            <label>Proyecto</label>
+            <div class="row">
+              <select id="mProyecto"></select>
+              <button class="btn" onclick="ui.addCatalog('proyecto')">＋</button>
+            </div>
+          </div>
+          <div>
+            <label>Objetivo</label>
+            <div class="row">
+              <select id="mObjetivo"></select>
+              <button class="btn" onclick="ui.addCatalog('objetivo')">＋</button>
+            </div>
+          </div>
+          <div style="grid-column:1/3">
+            <label>Descripción</label>
+            <textarea id="mDescripcion" placeholder="Detalles, pasos, etc."></textarea>
+          </div>
+          <div style="grid-column:1/3">
+            <label>Etiquetas (coma)</label>
+            <input id="mTags" type="text" placeholder="ej. QA, script, docs"/>
+          </div>
+        </div>
+      </div>
+      <footer>
+        <button class="btn danger" id="btnEliminar" onclick="deleteCurrent()" style="display:none">Eliminar</button>
+        <div class="spacer"></div>
+        <button class="btn" onclick="closeEdit()">Cancelar</button>
+        <button class="btn primary" onclick="saveFromModal()">Guardar</button>
+      </footer>
+    </div>
+  </div>
+
+  <!-- MODAL PROGRAMAR -->
+  <div class="modal-backdrop" id="modalProgBg">
+    <div class="modal" role="dialog" aria-modal="true">
+      <header>
+        <strong>Programar tarea</strong>
+        <button class="btn" onclick="closeProgram()">✕</button>
+      </header>
+      <div class="body">
+        <div class="grid">
+          <div>
+            <label>Programado para</label>
+            <input id="pProgramado" type="date"/>
+          </div>
+          <div>
+            <label>Fecha compromiso</label>
+            <input id="pCompromiso" type="date"/>
+          </div>
+        </div>
+      </div>
+      <footer>
+        <button class="btn" onclick="closeProgram()">Cancelar</button>
+        <button class="btn primary" onclick="saveProgram()">Guardar</button>
+      </footer>
+    </div>
+  </div>
+
+  <script src="backlog.js"></script>
+</body>
+</html>

--- a/backlog.js
+++ b/backlog.js
@@ -1,0 +1,158 @@
+// ====== Datos y almacenamiento (LocalStorage) ============================
+const LS_KEY = 'wb_tasks_v1';
+const LS_CAT = 'wb_catalogs_v1';
+
+/** @type {Array<any>} */
+let tasks = [];
+let catalogs = { tipos:["General"], proyectos:["Personal"], objetivos:["General"] };
+
+function load(){
+  try{ tasks = JSON.parse(localStorage.getItem(LS_KEY)||'[]'); }catch{ tasks=[] }
+  try{ catalogs = JSON.parse(localStorage.getItem(LS_CAT)||'null') || catalogs }catch{}
+}
+function save(){
+  localStorage.setItem(LS_KEY, JSON.stringify(tasks));
+  localStorage.setItem(LS_CAT, JSON.stringify(catalogs));
+}
+
+// ====== Utilidades =======================================================
+function escapeHtml(s){return (s||'').replace(/[&<>"']/g, c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#039;"}[c]))}
+function getTask(id){ return tasks.find(t=>t.id===id); }
+
+function fillSelect(sel, items){
+  sel.innerHTML='';
+  items.forEach(x=>{ const o=document.createElement('option'); o.value=o.textContent=x; sel.appendChild(o); });
+}
+function refreshFilters(){
+  fillSelect(mTipo, catalogs.tipos);
+  fillSelect(mProyecto, catalogs.proyectos);
+  fillSelect(mObjetivo, catalogs.objetivos);
+}
+
+// ====== Render ===========================================================
+const tbody = document.getElementById('tbody');
+function render(){
+  const list = tasks.filter(t=>!t.programadoPara && !t.fechaCompromiso);
+  tbody.innerHTML='';
+  list.forEach((t,i)=>{
+    const tr=document.createElement('tr');
+    tr.innerHTML = `
+      <td class="right">${i+1}</td>
+      <td>${escapeHtml(t.titulo)}</td>
+      <td><button class="btn" onclick="openProgram('${t.id}')">Programar</button></td>
+    `;
+    tr.addEventListener('click', ev=>{ if(ev.target.closest('button')) return; openEdit(t.id); });
+    tbody.appendChild(tr);
+  });
+}
+
+// ====== Modal de edición =================================================
+const modalBg = document.getElementById('modalEditBg');
+const mTitulo = document.getElementById('mTitulo');
+const mDescripcion = document.getElementById('mDescripcion');
+const mTipo = document.getElementById('mTipo');
+const mProyecto = document.getElementById('mProyecto');
+const mObjetivo = document.getElementById('mObjetivo');
+const mTags = document.getElementById('mTags');
+const btnEliminar = document.getElementById('btnEliminar');
+const modalTitle = document.getElementById('modalTitle');
+let editingId = null;
+
+function openEdit(id){
+  refreshFilters();
+  if(id){
+    const t=getTask(id); if(!t) return;
+    editingId=id;
+    modalTitle.textContent='Editar tarea';
+    btnEliminar.style.display='inline-flex';
+    mTitulo.value=t.titulo||'';
+    mDescripcion.value=t.descripcion||'';
+    mTipo.value=t.tipo||catalogs.tipos[0];
+    mProyecto.value=t.proyecto||catalogs.proyectos[0];
+    mObjetivo.value=t.objetivo||catalogs.objetivos[0];
+    mTags.value=(t.tags||[]).join(', ');
+  }else{
+    editingId=null;
+    modalTitle.textContent='Nueva tarea';
+    btnEliminar.style.display='none';
+    mTitulo.value=mDescripcion.value=mTags.value='';
+    mTipo.value=catalogs.tipos[0]||'General';
+    mProyecto.value=catalogs.proyectos[0]||'Personal';
+    mObjetivo.value=catalogs.objetivos[0]||'General';
+  }
+  modalBg.style.display='flex';
+}
+function closeEdit(){ modalBg.style.display='none'; }
+
+function saveFromModal(){
+  const data={
+    titulo:mTitulo.value.trim(),
+    descripcion:mDescripcion.value.trim(),
+    tipo:mTipo.value,
+    proyecto:mProyecto.value,
+    objetivo:mObjetivo.value,
+    tags:mTags.value.split(',').map(s=>s.trim()).filter(Boolean)
+  };
+  if(!data.titulo) return alert('Título requerido.');
+  if(editingId){
+    const t=getTask(editingId); Object.assign(t,data); save();
+  }else{
+    const t={
+      id:crypto.randomUUID(),
+      creadoEn:new Date().toISOString(),
+      estado:'PROGRAMADO',
+      sesiones:[],
+      timerStart:null,
+      adjuntos:[],
+      programadoPara:null,
+      fechaCompromiso:null,
+      ...data
+    };
+    tasks.unshift(t); save();
+  }
+  closeEdit(); render();
+}
+function deleteCurrent(){
+  if(!editingId) return;
+  const idx=tasks.findIndex(x=>x.id===editingId);
+  if(idx>=0){ tasks.splice(idx,1); save(); }
+  closeEdit(); render();
+}
+
+// ====== Modal Programar ==================================================
+const modalProgBg = document.getElementById('modalProgBg');
+const pProgramado = document.getElementById('pProgramado');
+const pCompromiso = document.getElementById('pCompromiso');
+let progId=null;
+function openProgram(id){ const t=getTask(id); if(!t) return; progId=id; pProgramado.value=t.programadoPara||''; pCompromiso.value=t.fechaCompromiso||''; modalProgBg.style.display='flex'; }
+function closeProgram(){ modalProgBg.style.display='none'; progId=null; }
+function saveProgram(){ const t=getTask(progId); if(!t) return; t.programadoPara=pProgramado.value||null; t.fechaCompromiso=pCompromiso.value||null; save(); closeProgram(); render(); }
+
+// ====== Catálogos ========================================================
+const ui={
+  addCatalog(kind){
+    const name=prompt('Nuevo '+kind+':');
+    if(!name) return;
+    const list=kind==='tipo'?catalogs.tipos:(kind==='proyecto'?catalogs.proyectos:catalogs.objetivos);
+    if(!list.includes(name)) list.push(name);
+    save(); refreshFilters();
+  }
+};
+
+// ====== Eventos ==========================================================
+document.getElementById('btnNueva').addEventListener('click',()=>openEdit(null));
+document.getElementById('menuToggle')?.addEventListener('click',()=>{ document.body.classList.toggle('collapsed'); });
+
+// Expose globals for inline handlers
+window.openProgram=openProgram;
+window.closeProgram=closeProgram;
+window.saveProgram=saveProgram;
+window.openEdit=openEdit;
+window.closeEdit=closeEdit;
+window.saveFromModal=saveFromModal;
+window.deleteCurrent=deleteCurrent;
+window.ui=ui;
+
+// ====== Boot =============================================================
+load();
+render();

--- a/gestor_personal_tablero_v_1.html
+++ b/gestor_personal_tablero_v_1.html
@@ -10,9 +10,10 @@
     <aside class="sidebar">
       <button class="burger" id="menuToggle">☰</button>
       <h2>Menu</h2>
-      <nav>
-        <a href="#" class="active">Workboard</a>
-      </nav>
+        <nav>
+          <a href="#" class="active">Workboard</a>
+          <a href="backlog.html">Backlog</a>
+        </nav>
     </aside>
     <div class="content">
     <div class="container">

--- a/script.js
+++ b/script.js
@@ -110,7 +110,8 @@ function load(){
     const text = q.value.trim().toLowerCase();
     const fp = fProyecto.value, fo = fObjetivo.value, ft = fTipo.value;
 
-    const filtered = tasks.filter(t=>{
+  const filtered = tasks.filter(t=>{
+      if(!t.programadoPara && !t.fechaCompromiso) return false;
       if(fp && t.proyecto!==fp) return false;
       if(fo && t.objetivo!==fo) return false;
       if(ft && t.tipo!==ft) return false;


### PR DESCRIPTION
## Summary
- Create `backlog.html` and `backlog.js` for managing unscheduled tasks with a Programar modal
- Hide unscheduled tasks from main workboard and add navigation link to backlog

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcbf0807483208d669f16e6c3ccfa