### PR TITLE
Fix day parsing for today's time column

### DIFF
--- a/script.js
+++ b/script.js
@@ -106,7 +106,7 @@ function load(){
   }
 
   function render(){
-    const day = fFecha.value ? new Date(fFecha.value) : new Date();
+    const day = fFecha.valueAsDate || new Date();
     const text = q.value.trim().toLowerCase();
     const fp = fProyecto.value, fo = fObjetivo.value, ft = fTipo.value;
 


### PR DESCRIPTION
## Summary
- Fix today's time column by using valueAsDate to get selected day

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdcc6389608320b29e60a35c75d25d