### PR TITLE
Fix daily time display in 'T. HOY' column

### DIFF
--- a/script.js
+++ b/script.js
@@ -106,7 +106,7 @@ function load(){
   }
 
   function render(){
-    const day = fFecha.value ? new Date(fFecha.value) : new Date();
+    const today = new Date();
     const text = q.value.trim().toLowerCase();
     const fp = fProyecto.value, fo = fObjetivo.value, ft = fTipo.value;
 
@@ -159,7 +159,7 @@ function load(){
           <td><span class=\"badge ${st.toLowerCase()}\">${st}</span></td>
           <td>${t.fechaCompromiso? new Date(t.fechaCompromiso).toLocaleDateString(): '—'}</td>
           <td>${fmtHM(getTotalMs(t))}</td>
-          <td>${fmtHM(getDayMs(t, day))}</td>
+          <td>${fmtHM(getDayMs(t, today))}</td>
           <td>
             <div style=\"position:relative\">
               <button class=\"menu-btn\" onclick=\"openMenu(event, '${t.id}')\">⋮</button>


### PR DESCRIPTION
## Summary
- Ensure "T. HOY" column shows time registered for the current day

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcc6389608320b29e60a35c75d25d