### PR TITLE
Fix Adjuntar button in close task modal

### DIFF
--- a/gestor_personal_tablero_v_1.html
+++ b/gestor_personal_tablero_v_1.html
@@ -154,7 +154,7 @@
           <div>
             <label>Adjuntar evidencia (requerido)</label>
             <input type="file" id="cFile"/>
-            <button class="btn" onclick="attachSelectedClose()">Adjuntar</button>
+            <button class="btn" onclick="ui.attachSelectedClose()">Adjuntar</button>
           </div>
         </div>
         <div id="cAdjuntos" class="small" style="margin-top:8px"></div>

--- a/script.js
+++ b/script.js
@@ -380,6 +380,20 @@ function load(){
         save(); renderAdjuntos(t); render(); mFile.value='';
       };
       reader.readAsDataURL(file);
+    },
+    attachSelectedClose(){
+      const file = cFile.files[0];
+      if(!file){ alert('Elige un archivo.'); return; }
+      const reader = new FileReader();
+      reader.onload = ()=>{
+        const t = getTask(closingId);
+        t.adjuntos = t.adjuntos||[];
+        t.adjuntos.push({ name:file.name, type:file.type, size:file.size, dataUrl:reader.result });
+        save();
+        renderCloseAdj();
+        cFile.value='';
+      };
+      reader.readAsDataURL(file);
     }
   }
 
@@ -440,12 +454,6 @@ function load(){
       const del = document.createElement('button'); del.className='btn'; del.textContent='Quitar'; del.onclick=()=>{ t.adjuntos.splice(idx,1); save(); renderCloseAdj(); };
       row.appendChild(del); cAdjuntos.appendChild(row);
     });
-  }
-  function attachSelectedClose(){
-    const file = cFile.files[0]; if(!file){ alert('Elige un archivo.'); return; }
-    const reader = new FileReader();
-    reader.onload = ()=>{ const t=getTask(closingId); t.adjuntos=t.adjuntos||[]; t.adjuntos.push({name:file.name,type:file.type,size:file.size,dataUrl:reader.result}); save(); renderCloseAdj(); };
-    reader.readAsDataURL(file);
   }
   function confirmClose(){ const t=getTask(closingId); if(!t) return; closeTask(t); closeClose(); }
 


### PR DESCRIPTION
## Summary
- Wire up close-task attachment button through ui object
- Add attachSelectedClose implementation that saves file and clears input

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd21cb9fc83208ce6b0a13cc15a95