### PR TITLE
Restore manual close-task buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -441,13 +441,31 @@ function load(){
       row.appendChild(del); cAdjuntos.appendChild(row);
     });
   }
-  function attachSelectedClose(){
-    const file = cFile.files[0]; if(!file){ alert('Elige un archivo.'); return; }
+function attachSelectedClose(){
+    const file = cFile.files[0];
+    if(!file){ alert('Elige un archivo.'); return; }
+    const t = getTask(closingId);
+    if(!t){ alert('No hay tarea seleccionada.'); return; }
     const reader = new FileReader();
-    reader.onload = ()=>{ const t=getTask(closingId); t.adjuntos=t.adjuntos||[]; t.adjuntos.push({name:file.name,type:file.type,size:file.size,dataUrl:reader.result}); save(); renderCloseAdj(); };
+    reader.onload = ()=>{
+      t.adjuntos = t.adjuntos || [];
+      t.adjuntos.push({ name:file.name, type:file.type, size:file.size, dataUrl:reader.result });
+      save();
+      renderCloseAdj();
+      cFile.value = '';
+    };
     reader.readAsDataURL(file);
-  }
-  function confirmClose(){ const t=getTask(closingId); if(!t) return; closeTask(t); closeClose(); }
+}
+function confirmClose(){
+    const t = getTask(closingId);
+    if(!t){ alert('No hay tarea seleccionada.'); return; }
+    closeTask(t);
+    closeClose();
+}
+
+// expose close modal helpers for inline handlers
+window.attachSelectedClose = attachSelectedClose;
+window.confirmClose = confirmClose;
 
   // ====== Export ===========================================================
   document.getElementById('btnExport').addEventListener('click', ()=>{


### PR DESCRIPTION
## Summary
- reintroduce Adjuntar and Cerrar tarea buttons in close modal
- handle attachment saving and task closing through explicit actions
- expose close-task helpers on window so inline buttons work correctly

## Testing
- `node --check script.js`
- `node --check backlog.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdd21cb9fc83208ce6b0a13cc15a95